### PR TITLE
Add minimal accounting CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Python
+__pycache__/
+*.py[cod]
+
+# accounting data
+accounting-app/records.csv

--- a/accounting-app/README.md
+++ b/accounting-app/README.md
@@ -1,0 +1,12 @@
+# 简易记账软件
+
+一个用于记录个人收支的命令行工具，数据存储在本地 `records.csv` 文件中。
+
+## 快速开始
+
+需要 Python 3.8 以上版本。
+
+```bash
+python app.py add 100 -c 餐饮 -d 午餐
+python app.py list
+```

--- a/accounting-app/app.py
+++ b/accounting-app/app.py
@@ -1,0 +1,48 @@
+import argparse
+import csv
+import os
+from datetime import datetime
+
+DATA_FILE = os.path.join(os.path.dirname(__file__), 'records.csv')
+
+def add_record(args):
+    date = args.date or datetime.now().strftime('%Y-%m-%d')
+    is_new = not os.path.exists(DATA_FILE)
+    with open(DATA_FILE, 'a', newline='') as f:
+        writer = csv.writer(f)
+        if is_new:
+            writer.writerow(['date', 'category', 'amount', 'description'])
+        writer.writerow([date, args.category, args.amount, args.description])
+    print('Record added.')
+
+def list_records(args):
+    if not os.path.exists(DATA_FILE):
+        print('No records found.')
+        return
+    with open(DATA_FILE, newline='') as f:
+        reader = csv.reader(f)
+        for row in reader:
+            print('\t'.join(row))
+
+def main():
+    parser = argparse.ArgumentParser(description='简单记账工具')
+    subparsers = parser.add_subparsers(dest='command')
+
+    add_parser = subparsers.add_parser('add', help='添加记录')
+    add_parser.add_argument('amount', type=float, help='金额')
+    add_parser.add_argument('-c', '--category', default='misc', help='分类')
+    add_parser.add_argument('-d', '--description', default='', help='描述')
+    add_parser.add_argument('--date', help='日期 YYYY-MM-DD')
+    add_parser.set_defaults(func=add_record)
+
+    list_parser = subparsers.add_parser('list', help='列出所有记录')
+    list_parser.set_defaults(func=list_records)
+
+    args = parser.parse_args()
+    if hasattr(args, 'func'):
+        args.func(args)
+    else:
+        parser.print_help()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a simple command-line accounting tool
- ignore Python artifacts and generated CSV data

## Testing
- `python accounting-app/app.py list`
- `python accounting-app/app.py add 50 -c Test -d testing`
- `python accounting-app/app.py list`


------
https://chatgpt.com/codex/tasks/task_e_684100ee50ec83298ea4cf0d5c5455cc